### PR TITLE
Resolve ArgumentError for Rails 5

### DIFF
--- a/app/controllers/remote_rails_rake_runner/runner_controller.rb
+++ b/app/controllers/remote_rails_rake_runner/runner_controller.rb
@@ -3,7 +3,7 @@ require_dependency 'remote_rails_rake_runner/application_controller'
 module RemoteRailsRakeRunner
   class RunnerController < ApplicationController
     before_filter :load_rake
-    skip_before_action :verify_authenticity_token
+    skip_before_action :verify_authenticity_token rescue ArgumentError
 
     def index
       tasks = Rake.application.tasks.map do |t|


### PR DESCRIPTION
When using Rails 5, the API always returns ArgumentError message 'Before process_action callback :verify_authenticity_token has not been defined'. This fix will rescue the error with no operation.